### PR TITLE
Default loading text for Android, looks bare otherwise

### DIFF
--- a/src/android/progress-dialog.ts
+++ b/src/android/progress-dialog.ts
@@ -19,7 +19,7 @@ export class LoadingIndicator {
           if (options.android.cancelable !== undefined) cancelable = options.android.cancelable;
         }
         
-        this._progressDialog = android.app.ProgressDialog.show(context, "", options.message || "", indeterminate, cancelable);  
+        this._progressDialog = android.app.ProgressDialog.show(context, "", options.message || "Loading", indeterminate, cancelable);  
       } else {
         // options
         if (options.message) this._progressDialog.setMesssage(options.message);


### PR DESCRIPTION
@NathanWalker are you happy with this? I feel since ProgressDialog's only look good with text (they look awfully bare without), it'd be sensible to default to "Loading" unless specified.
