### PR TITLE
Fix for latest nativescript-dev-webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/pocketsmith/nativescript-loading-indicator.git"
   },
-  "main": "loading-indicator.js",
+  "main": "loading-indicator",
   "typings": "index.d.ts",
   "author": "Nathan Walker <walkerrunpdx@gmail.com>",
   "contributors": [


### PR DESCRIPTION
Fixed webpack build based on https://docs.nativescript.org/tooling/bundling-with-webpack#referencing-platform-specific-modules-from-packagejson