### PR TITLE
Fixed typo that prevents status from being updated after progressDialog is shown on Android.

### DIFF
--- a/src/android/progress-dialog.ts
+++ b/src/android/progress-dialog.ts
@@ -26,7 +26,7 @@ export class LoadingIndicator {
         this._progressDialog = android.app.ProgressDialog.show(context, "", options.message || "Loading", indeterminate, cancelable, cancelListener);
       } else if (this._progressDialog) {
         // options
-        if (options.message && this._progressDialog.setMesssage) this._progressDialog.setMesssage(options.message);
+        if (options.message && this._progressDialog.setMessage) this._progressDialog.setMessage(options.message);
         if (options.progress) this._progressDialog.setProgress(options.progress);
         // android specific
         if (options.android) {


### PR DESCRIPTION
When creating a loader object, you can pass parameters through, including a message:

```
var options = { message : "This is the first message." };
loader.show(options);
```

However, when updating the message later with the loader already shown on screen, nothing happens:

```
options.message = "Message changed!";
loader.show(options);
```

This appears to happen because there is a typo in /src/android/progress-dialog.ts - _progressDialog.setMessage on line 26 is written as _progressDialog.setMesssage (three 's' characters).